### PR TITLE
Make cookies sending by default

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,8 @@ export const apiRequest = (url, accessToken, options = {}) => {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/vnd.api+json',
-      Accept: 'application/vnd.api+json'
+      Accept: 'application/vnd.api+json',
+      credentials: 'same-origin',
     },
     ...options
   };


### PR DESCRIPTION
It's kinda strange since average website uses cookies to authorize users and so on. Anyways, we have to allow users to configure `apiRequest` params somehow. WDYT?
